### PR TITLE
order - product 도메인 간 통신 설정

### DIFF
--- a/order/build.gradle
+++ b/order/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.0'
+	id 'org.springframework.boot' version '3.3.1'
 	id 'io.spring.dependency-management' version '1.1.6'
 }
 
@@ -34,8 +34,16 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 //	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.2"
+	}
 }

--- a/order/src/main/java/com/sparta/msa/order/OrderApplication.java
+++ b/order/src/main/java/com/sparta/msa/order/OrderApplication.java
@@ -2,7 +2,10 @@ package com.sparta.msa.order;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+
+@EnableFeignClients
 @SpringBootApplication
 public class OrderApplication {
 

--- a/order/src/main/java/com/sparta/msa/order/application/service/OrderService.java
+++ b/order/src/main/java/com/sparta/msa/order/application/service/OrderService.java
@@ -9,7 +9,7 @@ import com.sparta.msa.order.exception.CommonResponse;
 import com.sparta.msa.order.exception.CustomException;
 import com.sparta.msa.order.exception.ErrorCode;
 import com.sparta.msa.order.infrastructure.client.ProductClient;
-import com.sparta.msa.order.infrastructure.client.ProductResponse;
+import com.sparta.msa.order.infrastructure.client.ProductInfo;
 import com.sparta.msa.order.infrastructure.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -30,9 +30,7 @@ public class OrderService {
     // 주문 생성
     @Transactional
     public OrderResponse createOrder(OrderRequest request) {
-        System.out.println("Start validating product with UUID: " + request.getProductUUID());
-        ProductResponse productResponse = productClient.getProductById(request.getProductUUID());
-        System.out.println("ProductResponse received: " + productResponse);
+        ProductInfo productResponse = productClient.getProductById(request.getProductUUID());
 
         if (productResponse == null || productResponse.getQuantity() <= 0) {
             throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);

--- a/order/src/main/java/com/sparta/msa/order/infrastructure/client/ProductClient.java
+++ b/order/src/main/java/com/sparta/msa/order/infrastructure/client/ProductClient.java
@@ -10,5 +10,5 @@ import java.util.UUID;
 public interface ProductClient {
 
     @GetMapping("/products/{productId}")
-    ProductResponse getProductById(@PathVariable UUID productId);
+    ProductInfo getProductById(@PathVariable UUID productId);
 }

--- a/order/src/main/java/com/sparta/msa/order/infrastructure/client/ProductClient.java
+++ b/order/src/main/java/com/sparta/msa/order/infrastructure/client/ProductClient.java
@@ -1,0 +1,14 @@
+package com.sparta.msa.order.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(name = "product")
+public interface ProductClient {
+
+    @GetMapping("/products/{productId}")
+    ProductResponse getProductById(@PathVariable UUID productId);
+}

--- a/order/src/main/java/com/sparta/msa/order/infrastructure/client/ProductInfo.java
+++ b/order/src/main/java/com/sparta/msa/order/infrastructure/client/ProductInfo.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ProductResponse {
+public class ProductInfo {
     private UUID productUUID;
     private String name;
     private Integer quantity;

--- a/order/src/main/java/com/sparta/msa/order/infrastructure/client/ProductResponse.java
+++ b/order/src/main/java/com/sparta/msa/order/infrastructure/client/ProductResponse.java
@@ -1,0 +1,18 @@
+package com.sparta.msa.order.infrastructure.client;
+
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductResponse {
+    private UUID productUUID;
+    private String name;
+    private Integer quantity;
+    private UUID companyUUID;
+    private UUID hubUUID;
+}

--- a/order/src/main/resources/application.yaml
+++ b/order/src/main/resources/application.yaml
@@ -7,14 +7,26 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  application:
+    name: order
 
 server:
   port: 19096
 
 logging:
   level:
-    root: info
+    org.springframework.cloud.openfeign: DEBUG
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka/
+
+feign:
+  hystrix:
+    enabled: true

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.0'
+	id 'org.springframework.boot' version '3.3.1'
 	id 'io.spring.dependency-management' version '1.1.6'
 }
 
@@ -31,8 +31,17 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.2"
+	}
 }

--- a/product/src/main/java/com/sparta/msa/product/ProductApplication.java
+++ b/product/src/main/java/com/sparta/msa/product/ProductApplication.java
@@ -2,7 +2,9 @@ package com.sparta.msa.product;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class ProductApplication {
 

--- a/product/src/main/java/com/sparta/msa/product/application/dto/CreateProductRequest.java
+++ b/product/src/main/java/com/sparta/msa/product/application/dto/CreateProductRequest.java
@@ -1,10 +1,16 @@
 package com.sparta.msa.product.application.dto;
 
-import lombok.Data;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
 import java.util.UUID;
 
-@Data
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class CreateProductRequest {
     private String name;
     private Integer quantity;

--- a/product/src/main/java/com/sparta/msa/product/application/dto/ProductResponse.java
+++ b/product/src/main/java/com/sparta/msa/product/application/dto/ProductResponse.java
@@ -1,13 +1,17 @@
 package com.sparta.msa.product.application.dto;
 
 import com.sparta.msa.product.domain.model.Product;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 
 import java.util.UUID;
 
-@Data
+@Getter
+@NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class ProductResponse {
     private UUID productUUID;
     private String name;

--- a/product/src/main/java/com/sparta/msa/product/application/dto/UpdateProductRequest.java
+++ b/product/src/main/java/com/sparta/msa/product/application/dto/UpdateProductRequest.java
@@ -1,10 +1,16 @@
 package com.sparta.msa.product.application.dto;
 
-import lombok.Data;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
 import java.util.UUID;
 
-@Data
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class UpdateProductRequest {
     private UUID productUUID;
     private String name;

--- a/product/src/main/resources/application.yaml
+++ b/product/src/main/resources/application.yaml
@@ -11,6 +11,8 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  application:
+    name: product
 
 server:
   port: 19092
@@ -18,3 +20,12 @@ server:
 logging:
   level:
     root: info
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka/
+
+feign:
+  hystrix:
+    enabled: true


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #32 

## 📝 Description
1. 기존에 작업했던 DTO, Entity에 대해서 @Data 사용 대신 다른 어노테이션을 사용했습니다.
2. gradle, yaml 파일에 feign, eureka 설정을 추가했습니다.
3. 통신을 위한 DTO, Interface 생성하고 이를 통해 기존에 임시 값으로 처리되던 주문 생성의 ProductUUID 부분을 실제로 존재하는 상품만 주문이 가능하도록 변경했습니다.
4. 그 외의 feign 설정했습니다.

## 💬 To Reivewers
Feign 종속성 관련해서 연결이 원활하지 않아 튜터님의 추천대로 스프링부트 3.3.1 버전으로 변경해서 사용했습니다. 문제는 없을 것입니다. 참고바랍니다.
