### PR TITLE
배송 담당자 엔티티 생성 및 배송 담당자 Create 구현, 배송 담당자 배정 구현

### DIFF
--- a/delivery/src/main/java/com/sparta/msa/delivery/application/dto/deliveryManager/DeliveryManagerRequest.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/application/dto/deliveryManager/DeliveryManagerRequest.java
@@ -1,0 +1,15 @@
+package com.sparta.msa.delivery.application.dto.deliveryManager;
+
+import com.sparta.msa.delivery.domain.model.DeliveryManagerType;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class DeliveryManagerRequest {
+    private String username;
+    private UUID hubUUID;
+    private String slackId;
+    private DeliveryManagerType type;
+    private int deliveryOrder;
+}

--- a/delivery/src/main/java/com/sparta/msa/delivery/application/dto/deliveryManager/DeliveryManagerRequest.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/application/dto/deliveryManager/DeliveryManagerRequest.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 public class DeliveryManagerRequest {
     private String username;
     private UUID hubUUID;
-    private String slackId;
     private DeliveryManagerType type;
     private int deliveryOrder;
 }

--- a/delivery/src/main/java/com/sparta/msa/delivery/application/dto/deliveryManager/DeliveryManagerResponse.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/application/dto/deliveryManager/DeliveryManagerResponse.java
@@ -1,0 +1,24 @@
+package com.sparta.msa.delivery.application.dto.deliveryManager;
+
+import com.sparta.msa.delivery.domain.model.DeliveryManager;
+import com.sparta.msa.delivery.domain.model.DeliveryManagerType;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class DeliveryManagerResponse {
+    private String username;
+    private UUID hubUUID;
+    private String slackId;
+    private DeliveryManagerType type;
+    private int deliveryOrder;
+
+    public DeliveryManagerResponse(DeliveryManager deliveryManager) {
+        this.username = deliveryManager.getUsername();
+        this.hubUUID = deliveryManager.getHubUUID();
+        this.slackId = deliveryManager.getSlackId();
+        this.type = deliveryManager.getType();
+        this.deliveryOrder = deliveryManager.getDeliveryOrder();
+    }
+}

--- a/delivery/src/main/java/com/sparta/msa/delivery/application/dto/deliveryManager/DeliveryManagerResponse.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/application/dto/deliveryManager/DeliveryManagerResponse.java
@@ -10,14 +10,12 @@ import java.util.UUID;
 public class DeliveryManagerResponse {
     private String username;
     private UUID hubUUID;
-    private String slackId;
     private DeliveryManagerType type;
     private int deliveryOrder;
 
     public DeliveryManagerResponse(DeliveryManager deliveryManager) {
         this.username = deliveryManager.getUsername();
         this.hubUUID = deliveryManager.getHubUUID();
-        this.slackId = deliveryManager.getSlackId();
         this.type = deliveryManager.getType();
         this.deliveryOrder = deliveryManager.getDeliveryOrder();
     }

--- a/delivery/src/main/java/com/sparta/msa/delivery/application/service/DeliveryManagerService.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/application/service/DeliveryManagerService.java
@@ -1,0 +1,35 @@
+package com.sparta.msa.delivery.application.service;
+
+import com.sparta.msa.delivery.application.dto.deliveryManager.DeliveryManagerRequest;
+import com.sparta.msa.delivery.application.dto.deliveryManager.DeliveryManagerResponse;
+import com.sparta.msa.delivery.domain.model.DeliveryManager;
+import com.sparta.msa.delivery.infrastructure.repository.DeliveryManagerJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryManagerService {
+
+    private final DeliveryManagerJpaRepository deliveryManagerJpaRepository;
+
+    @Transactional
+    public DeliveryManagerResponse addDeliveryManager(DeliveryManagerRequest request) {
+
+        Integer lastOrder = deliveryManagerJpaRepository.findLastDeliveryOrder();
+        int nextOrder = (lastOrder != null) ? lastOrder + 1 : 1;
+
+        DeliveryManager deliveryManager = DeliveryManager.create(
+                request.getHubUUID(),
+                request.getSlackId(),
+                request.getType(),
+                nextOrder,
+                request.getUsername()
+        );
+
+        deliveryManagerJpaRepository.save(deliveryManager);
+        return new DeliveryManagerResponse(deliveryManager);
+    }
+
+}

--- a/delivery/src/main/java/com/sparta/msa/delivery/application/service/DeliveryManagerService.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/application/service/DeliveryManagerService.java
@@ -3,6 +3,8 @@ package com.sparta.msa.delivery.application.service;
 import com.sparta.msa.delivery.application.dto.deliveryManager.DeliveryManagerRequest;
 import com.sparta.msa.delivery.application.dto.deliveryManager.DeliveryManagerResponse;
 import com.sparta.msa.delivery.domain.model.DeliveryManager;
+import com.sparta.msa.delivery.infrastructure.exception.CustomException;
+import com.sparta.msa.delivery.infrastructure.exception.ErrorCode;
 import com.sparta.msa.delivery.infrastructure.repository.DeliveryManagerJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,6 +29,18 @@ public class DeliveryManagerService {
                 nextOrder,
                 request.getUsername()
         );
+
+        deliveryManagerJpaRepository.save(deliveryManager);
+        return new DeliveryManagerResponse(deliveryManager);
+    }
+
+    @Transactional
+    public DeliveryManagerResponse assignDeliveryManager() {
+        DeliveryManager deliveryManager = deliveryManagerJpaRepository.findTopByIsDeletedFalseOrderByDeliveryOrderAsc()
+                .orElseThrow(() -> new CustomException(ErrorCode.DELIVERY_MANAGER_NOT_FOUND));
+
+        Integer lastOrder = deliveryManagerJpaRepository.findLastDeliveryOrder();
+        deliveryManager.updateDeliveryOrder((lastOrder != null) ? lastOrder + 1 : 1);
 
         deliveryManagerJpaRepository.save(deliveryManager);
         return new DeliveryManagerResponse(deliveryManager);

--- a/delivery/src/main/java/com/sparta/msa/delivery/application/service/DeliveryManagerService.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/application/service/DeliveryManagerService.java
@@ -24,10 +24,9 @@ public class DeliveryManagerService {
 
         DeliveryManager deliveryManager = DeliveryManager.create(
                 request.getHubUUID(),
-                request.getSlackId(),
                 request.getType(),
-                nextOrder,
-                request.getUsername()
+                request.getUsername(),
+                nextOrder
         );
 
         deliveryManagerJpaRepository.save(deliveryManager);

--- a/delivery/src/main/java/com/sparta/msa/delivery/domain/model/DeliveryManager.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/domain/model/DeliveryManager.java
@@ -70,4 +70,9 @@ public class DeliveryManager extends BaseEntity {
         this.deletedAt = LocalDateTime.now();
         this.deletedBy = deletedBy;
     }
+
+    public void updateDeliveryOrder(int newOrder) {
+        this.deliveryOrder = newOrder;
+    }
+
 }

--- a/delivery/src/main/java/com/sparta/msa/delivery/domain/model/DeliveryManager.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/domain/model/DeliveryManager.java
@@ -21,9 +21,6 @@ public class DeliveryManager extends BaseEntity {
     @Column(name = "hub_uuid", nullable = false)
     private UUID hubUUID;
 
-    @Column(name = "slack_id", length = 50, nullable = false)
-    private String slackId;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private DeliveryManagerType type;
@@ -42,25 +39,21 @@ public class DeliveryManager extends BaseEntity {
     private String deletedBy;
 
     public static DeliveryManager create(UUID hubUUID,
-                                         String slackId,
                                          DeliveryManagerType type,
-                                         int deliveryOrder,
-                                         String username) {
+                                         String username,
+                                         int deliveryOrder) {
         return DeliveryManager.builder()
                 .hubUUID(hubUUID)
-                .slackId(slackId)
                 .type(type)
-                .deliveryOrder(deliveryOrder)
                 .username(username)
+                .deliveryOrder(deliveryOrder)
                 .build();
     }
 
     public void update(UUID hubUUID,
-                       String slackId,
                        DeliveryManagerType type,
                        int deliveryOrder) {
         this.hubUUID = hubUUID;
-        this.slackId = slackId;
         this.type = type;
         this.deliveryOrder = deliveryOrder;
     }
@@ -74,5 +67,4 @@ public class DeliveryManager extends BaseEntity {
     public void updateDeliveryOrder(int newOrder) {
         this.deliveryOrder = newOrder;
     }
-
 }

--- a/delivery/src/main/java/com/sparta/msa/delivery/domain/model/DeliveryManager.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/domain/model/DeliveryManager.java
@@ -1,0 +1,73 @@
+package com.sparta.msa.delivery.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_delivery_manager")
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class DeliveryManager extends BaseEntity {
+
+    @Id
+    @Column(length = 10, nullable = false)
+    private String username;
+
+    @Column(name = "hub_uuid", nullable = false)
+    private UUID hubUUID;
+
+    @Column(name = "slack_id", length = 50, nullable = false)
+    private String slackId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DeliveryManagerType type;
+
+    @Column(name = "delivery_order", nullable = false)
+    private int deliveryOrder;
+
+    @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
+    private boolean isDeleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by", length = 10)
+    private String deletedBy;
+
+    public static DeliveryManager create(UUID hubUUID,
+                                         String slackId,
+                                         DeliveryManagerType type,
+                                         int deliveryOrder,
+                                         String username) {
+        return DeliveryManager.builder()
+                .hubUUID(hubUUID)
+                .slackId(slackId)
+                .type(type)
+                .deliveryOrder(deliveryOrder)
+                .username(username)
+                .build();
+    }
+
+    public void update(UUID hubUUID,
+                       String slackId,
+                       DeliveryManagerType type,
+                       int deliveryOrder) {
+        this.hubUUID = hubUUID;
+        this.slackId = slackId;
+        this.type = type;
+        this.deliveryOrder = deliveryOrder;
+    }
+
+    public void delete(String deletedBy) {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = deletedBy;
+    }
+}

--- a/delivery/src/main/java/com/sparta/msa/delivery/domain/model/DeliveryManagerType.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/domain/model/DeliveryManagerType.java
@@ -1,0 +1,6 @@
+package com.sparta.msa.delivery.domain.model;
+
+public enum DeliveryManagerType {
+    HUB_MANAGER,
+    COMPANY_MANAGER   
+}

--- a/delivery/src/main/java/com/sparta/msa/delivery/domain/model/DeliveryManagerType.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/domain/model/DeliveryManagerType.java
@@ -2,5 +2,5 @@ package com.sparta.msa.delivery.domain.model;
 
 public enum DeliveryManagerType {
     HUB_MANAGER,
-    COMPANY_MANAGER   
+    COMPANY_MANAGER
 }

--- a/delivery/src/main/java/com/sparta/msa/delivery/domain/repository/DeliveryManagerRepository.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/domain/repository/DeliveryManagerRepository.java
@@ -1,0 +1,5 @@
+package com.sparta.msa.delivery.domain.repository;
+
+public interface DeliveryManagerRepository {
+    
+}

--- a/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/exception/ErrorCode.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/exception/ErrorCode.java
@@ -8,7 +8,12 @@ public enum ErrorCode {
 
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다. (%s)"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
-    DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 정보를 찾을 수 없습니다.");
+    DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 정보를 찾을 수 없습니다."),
+    DELIVERY_MANAGER_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 담당자를 찾을 수 없습니다."),
+    HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 허브 ID입니다."),
+    DUPLICATE_DELIVERY_MANAGER(HttpStatus.CONFLICT, "이미 존재하는 배송 담당자입니다.");
+
+
     private final HttpStatus status;
     private final String description;
 

--- a/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
@@ -5,9 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 
 @Repository
 public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryManager, String> {
+
+    Optional<DeliveryManager> findTopByIsDeletedFalseOrderByDeliveryOrderAsc();
 
     @Query("SELECT MAX(dm.deliveryOrder) FROM DeliveryManager dm WHERE dm.isDeleted = false")
     Integer findLastDeliveryOrder();

--- a/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
@@ -1,0 +1,14 @@
+package com.sparta.msa.delivery.infrastructure.repository;
+
+import com.sparta.msa.delivery.domain.model.DeliveryManager;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryManager, String> {
+
+    @Query("SELECT MAX(dm.deliveryOrder) FROM DeliveryManager dm WHERE dm.isDeleted = false")
+    Integer findLastDeliveryOrder();
+}

--- a/delivery/src/main/java/com/sparta/msa/delivery/presentation/controller/DeliveryManagerController.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/presentation/controller/DeliveryManagerController.java
@@ -1,0 +1,24 @@
+package com.sparta.msa.delivery.presentation.controller;
+
+import com.sparta.msa.delivery.application.dto.deliveryManager.DeliveryManagerRequest;
+import com.sparta.msa.delivery.application.dto.deliveryManager.DeliveryManagerResponse;
+import com.sparta.msa.delivery.application.service.DeliveryManagerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/delivery/managers")
+@RequiredArgsConstructor
+public class DeliveryManagerController {
+
+    private final DeliveryManagerService deliveryManagerService;
+
+    @PostMapping
+    public ResponseEntity<DeliveryManagerResponse> addDeliveryManager(@RequestBody DeliveryManagerRequest request) {
+        DeliveryManagerResponse response = deliveryManagerService.addDeliveryManager(request);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/delivery/src/main/java/com/sparta/msa/delivery/presentation/controller/DeliveryManagerController.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/presentation/controller/DeliveryManagerController.java
@@ -21,4 +21,10 @@ public class DeliveryManagerController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/assign")
+    public ResponseEntity<DeliveryManagerResponse> assignDeliveryManager() {
+        DeliveryManagerResponse response = deliveryManagerService.assignDeliveryManager();
+        return ResponseEntity.ok(response);
+    }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #36 

## 📝 Description
배송 관리자에 관련된 엔티티를 생성하고 배송 관리자 생성 로직을 추가했습니다.

## 💬 To Reivewers
현재 <배송담당자 타입이 업체 배송 담당자인 경우, 소속 허브ID가 존재하는 허브인지 확인합니다.>와 <배송 담당자의 ID는 사용자 관리 엔티티의 사용자와 동일해야 합니다.(사용자 중에 배송 담당자가 있습니다.)>인 경우에 대해서는 구현하지 않은 상태입니다. 