### PR TITLE
배송 담당자 정보 수정 구현

### DIFF
--- a/delivery/src/main/java/com/sparta/msa/delivery/application/service/DeliveryManagerService.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/application/service/DeliveryManagerService.java
@@ -3,6 +3,7 @@ package com.sparta.msa.delivery.application.service;
 import com.sparta.msa.delivery.application.dto.deliveryManager.DeliveryManagerRequest;
 import com.sparta.msa.delivery.application.dto.deliveryManager.DeliveryManagerResponse;
 import com.sparta.msa.delivery.domain.model.DeliveryManager;
+import com.sparta.msa.delivery.domain.model.DeliveryManagerType;
 import com.sparta.msa.delivery.infrastructure.exception.CustomException;
 import com.sparta.msa.delivery.infrastructure.exception.ErrorCode;
 import com.sparta.msa.delivery.infrastructure.repository.DeliveryManagerJpaRepository;
@@ -18,6 +19,10 @@ public class DeliveryManagerService {
 
     @Transactional
     public DeliveryManagerResponse addDeliveryManager(DeliveryManagerRequest request) {
+
+        if (request.getType() == DeliveryManagerType.COMPANY_MANAGER && request.getHubUUID() == null) {
+            throw new IllegalArgumentException("소속 허브 ID는 필수입니다.");
+        }
 
         Integer lastOrder = deliveryManagerJpaRepository.findLastDeliveryOrder();
         int nextOrder = (lastOrder != null) ? lastOrder + 1 : 1;
@@ -44,5 +49,24 @@ public class DeliveryManagerService {
         deliveryManagerJpaRepository.save(deliveryManager);
         return new DeliveryManagerResponse(deliveryManager);
     }
+
+    @Transactional
+    public DeliveryManagerResponse updateDeliveryManager(String username, DeliveryManagerRequest request) {
+        DeliveryManager deliveryManager = deliveryManagerJpaRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 배송 담당자입니다."));
+
+        if (request.getType() == DeliveryManagerType.COMPANY_MANAGER && request.getHubUUID() == null) {
+            throw new IllegalArgumentException("소속 허브 ID는 필수입니다.");
+        }
+
+        deliveryManager.update(
+                request.getHubUUID(),
+                request.getType(),
+                deliveryManager.getDeliveryOrder()
+        );
+
+        return new DeliveryManagerResponse(deliveryManager);
+    }
+
 
 }

--- a/delivery/src/main/java/com/sparta/msa/delivery/application/service/DeliveryManagerService.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/application/service/DeliveryManagerService.java
@@ -68,5 +68,11 @@ public class DeliveryManagerService {
         return new DeliveryManagerResponse(deliveryManager);
     }
 
+    @Transactional
+    public void deleteDeliveryManager(String username) {
+        DeliveryManager deliveryManager = deliveryManagerJpaRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 배송 담당자입니다."));
 
+        deliveryManager.delete("system");
+    }
 }

--- a/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 @Repository
 public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryManager, String> {
+    Optional<DeliveryManager> findByUsername(String username);
 
     Optional<DeliveryManager> findTopByIsDeletedFalseOrderByDeliveryOrderAsc();
 

--- a/delivery/src/main/java/com/sparta/msa/delivery/presentation/controller/DeliveryManagerController.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/presentation/controller/DeliveryManagerController.java
@@ -27,4 +27,13 @@ public class DeliveryManagerController {
         return ResponseEntity.ok(response);
     }
 
+    @PutMapping("/{username}")
+    public ResponseEntity<DeliveryManagerResponse> updateDeliveryManager(
+            @PathVariable String username,
+            @RequestBody DeliveryManagerRequest request
+    ) {
+        DeliveryManagerResponse response = deliveryManagerService.updateDeliveryManager(username, request);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/delivery/src/main/java/com/sparta/msa/delivery/presentation/controller/DeliveryManagerController.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/presentation/controller/DeliveryManagerController.java
@@ -36,4 +36,10 @@ public class DeliveryManagerController {
         return ResponseEntity.ok(response);
     }
 
+    @DeleteMapping("/{username}")
+    public ResponseEntity<Void> deleteDeliveryManager(@PathVariable String username) {
+        deliveryManagerService.deleteDeliveryManager(username);
+        return ResponseEntity.noContent().build();
+    }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #36 

## 📝 Description
배송 담당자 정보 수정에 관한 구현했습니다.

## 💬 To Reivewers
현재 <배송 담당자의 ID는 사용자 관리 엔티티의 사용자와 동일해야 합니다.(사용자 중에 배송 담당자가 있습니다.)>인 경우에 대해서는 구현하지 않은 상태입니다.
