### PR TITLE
배송 담당자 리스트 조회 및 배송 담당자 검색 구현

### DIFF
--- a/delivery/src/main/java/com/sparta/msa/delivery/application/service/DeliveryManagerService.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/application/service/DeliveryManagerService.java
@@ -11,6 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class DeliveryManagerService {
@@ -74,5 +77,21 @@ public class DeliveryManagerService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 배송 담당자입니다."));
 
         deliveryManager.delete("system");
+    }
+
+    @Transactional(readOnly = true)
+    public List<DeliveryManagerResponse> getDeliveryManagers(String condition, String keyword) {
+        return deliveryManagerJpaRepository.search(condition, keyword)
+                .stream()
+                .map(DeliveryManagerResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public DeliveryManagerResponse getDeliveryManagerDetail(String username) {
+        DeliveryManager deliveryManager = deliveryManagerJpaRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 배송 담당자입니다."));
+
+        return new DeliveryManagerResponse(deliveryManager);
     }
 }

--- a/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -16,4 +17,9 @@ public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryMana
 
     @Query("SELECT MAX(dm.deliveryOrder) FROM DeliveryManager dm WHERE dm.isDeleted = false")
     Integer findLastDeliveryOrder();
+
+    @Query("SELECT dm FROM DeliveryManager dm WHERE " +
+            "(:condition IS NULL OR dm.type = :condition) AND " +
+            "(:keyword IS NULL OR dm.username LIKE %:keyword%)")
+    List<DeliveryManager> search(String condition, String keyword);
 }

--- a/delivery/src/main/java/com/sparta/msa/delivery/presentation/controller/DeliveryManagerController.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/presentation/controller/DeliveryManagerController.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RestController
 @RequestMapping("/delivery/managers")
@@ -40,6 +42,23 @@ public class DeliveryManagerController {
     public ResponseEntity<Void> deleteDeliveryManager(@PathVariable String username) {
         deliveryManagerService.deleteDeliveryManager(username);
         return ResponseEntity.noContent().build();
+    }
+
+    // 배송 담당자 목록 조회
+    @GetMapping
+    public ResponseEntity<List<DeliveryManagerResponse>> getDeliveryManagers(
+            @RequestParam(required = false) String condition,
+            @RequestParam(required = false) String keyword
+    ) {
+        List<DeliveryManagerResponse> response = deliveryManagerService.getDeliveryManagers(condition, keyword);
+        return ResponseEntity.ok(response);
+    }
+
+    // 배송 담당자 상세 조회
+    @GetMapping("/{username}")
+    public ResponseEntity<DeliveryManagerResponse> getDeliveryManagerDetail(@PathVariable String username) {
+        DeliveryManagerResponse response = deliveryManagerService.getDeliveryManagerDetail(username);
+        return ResponseEntity.ok(response);
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #36 

## 📝 Description
배송 담당자 리스트 조회 및 배송 담당자 검색 구현

## 💬 To Reivewers
현재는 JPA에서 쿼리문으로 검색하는데 order, product, deliverManager 엔티티 모두 QueryDSL로 수정할 예정입니다.