### PR TITLE
feature/9/user/user 조회 url 변경

### DIFF
--- a/user/src/main/java/com/sparta/user/infrastructure/config/SecurityConfig.java
+++ b/user/src/main/java/com/sparta/user/infrastructure/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST,"/users/signUp").permitAll()
                         .requestMatchers(HttpMethod.POST,"/users").hasAnyAuthority("MASTER")
                         .requestMatchers(HttpMethod.PUT,"/users/authority/{username}").hasAnyAuthority("MASTER")
-                        .requestMatchers(HttpMethod.GET, "/users/{username}").hasAnyAuthority("MASTER")
+                        .requestMatchers(HttpMethod.GET, "/users/info").hasAnyAuthority("MASTER")
                         .requestMatchers(HttpMethod.GET, "/users").hasAnyAuthority("MASTER")
                         .requestMatchers(HttpMethod.PUT, "/users/{username}").hasAnyAuthority("MASTER", "HUB_MANAGER", "COMPANY_MANAGER", "DELIVERY_MANAGER")
                         .requestMatchers(HttpMethod.DELETE, "/users/{username}").hasAnyAuthority("MASTER")

--- a/user/src/main/java/com/sparta/user/presentation/controller/UserController.java
+++ b/user/src/main/java/com/sparta/user/presentation/controller/UserController.java
@@ -93,10 +93,10 @@ public class UserController {
     }
 
     // 유저 조회
-    @GetMapping("/{username}")
+    @GetMapping("/info")
     public CommonResponse<UserRoleInfoResponseDto> getUserInfo(
             @RequestHeader("Authorization") String token,
-            @PathVariable String username) {
+            @RequestParam String username) {
         try {
             return userService.getUserInfoByUsername(token, username);
         } catch (CustomException e) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #9 
## 📝 Description
AI와 Alert에서 슬랙ID조회 GET users/slack-id
기존 user 조회 GET users/{username}
slack-id가 {username}으로 인식해서 오류가 있어서
![image](https://github.com/user-attachments/assets/90a10a10-a099-47e8-9a94-ea8491275a83)
유저 조회를 users/info로 바꿨습니다!

![image](https://github.com/user-attachments/assets/23707c17-d7bd-475d-a6c1-1a488ec68016)
