### PR TITLE
배송 매니저 권한 부여 및 분리

### DIFF
--- a/delivery/src/main/java/com/sparta/msa/delivery/application/dto/deliveryManager/DeliveryManagerRequest.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/application/dto/deliveryManager/DeliveryManagerRequest.java
@@ -7,8 +7,7 @@ import java.util.UUID;
 
 @Getter
 public class DeliveryManagerRequest {
-    private String username;
     private UUID hubUUID;
     private DeliveryManagerType type;
-    private int deliveryOrder;
+    private String username;
 }

--- a/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/exception/ErrorCode.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/exception/ErrorCode.java
@@ -8,13 +8,14 @@ public enum ErrorCode {
 
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다. (%s)"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
-  
+
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "해당 작업에 대한 권한이 없습니다."),
+
     DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 정보를 찾을 수 없습니다."),
-  
     DELIVERY_MANAGER_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 담당자를 찾을 수 없습니다."),
     HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 허브 ID입니다."),
     DUPLICATE_DELIVERY_MANAGER(HttpStatus.CONFLICT, "이미 존재하는 배송 담당자입니다."),
-  
     DELIVERY_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 경로 정보를 찾을 수 없습니다.");
 
     private final HttpStatus status;
@@ -24,5 +25,4 @@ public enum ErrorCode {
         this.status = status;
         this.description = description;
     }
-
 }

--- a/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/infrastructure/repository/DeliveryManagerJpaRepository.java
@@ -4,6 +4,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.StringPath;
 import com.sparta.msa.delivery.domain.model.DeliveryManager;
+import com.sparta.msa.delivery.domain.model.DeliveryManagerType;
 import com.sparta.msa.delivery.domain.model.QDeliveryManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,9 +12,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryManager, String>,
@@ -23,6 +27,26 @@ public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryMana
     Optional<DeliveryManager> findByUsername(String username);
 
     Optional<DeliveryManager> findTopByIsDeletedFalseOrderByDeliveryOrderAsc();
+
+    // 허브 배송 담당자 배정용
+    Optional<DeliveryManager> findTopByTypeAndIsDeletedFalseOrderByDeliveryOrderAsc(DeliveryManagerType type);
+
+    // 특정 허브의 업체 배송 담당자 배정용
+    Optional<DeliveryManager> findTopByTypeAndHubUUIDAndIsDeletedFalseOrderByDeliveryOrderAsc(
+            DeliveryManagerType type, UUID hubUUID);
+
+    // 허브 배송 담당자의 마지막 배정 순서 조회
+    @Query("SELECT MAX(dm.deliveryOrder) FROM DeliveryManager dm WHERE dm.type = :type AND dm.isDeleted = false")
+    Integer findLastDeliveryOrderByType(@Param("type") DeliveryManagerType type);
+
+    // 특정 허브의 업체 배송 담당자의 마지막 배정 순서 조회
+    @Query("SELECT MAX(dm.deliveryOrder) FROM DeliveryManager dm " +
+            "WHERE dm.type = :type AND dm.hubUUID = :hubUUID AND dm.isDeleted = false")
+    Integer findLastDeliveryOrderByTypeAndHubUUID(@Param("type") DeliveryManagerType type,
+                                                  @Param("hubUUID") UUID hubUUID);
+
+    @Query("SELECT MAX(d.deliveryOrder) FROM DeliveryManager d WHERE d.hubUUID = :hubUUID AND d.isDeleted = false")
+    Integer findLastDeliveryOrderByHubUUID(UUID hubUUID);
 
     default Integer findLastDeliveryOrder() {
         QDeliveryManager deliveryManager = QDeliveryManager.deliveryManager;
@@ -34,17 +58,13 @@ public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryMana
     @Override
     default void customize(QuerydslBindings bindings, QDeliveryManager root) {
         bindings.bind(root.username).first((StringPath path, String value) -> path.containsIgnoreCase(value));
-
         bindings.excluding(root.isDeleted, root.deliveryOrder);
     }
 
     default Page<DeliveryManager> findWithPredicate(Predicate predicate, Pageable pageable) {
         QDeliveryManager deliveryManager = QDeliveryManager.deliveryManager;
         BooleanBuilder builder = new BooleanBuilder(predicate);
-
         builder.and(deliveryManager.isDeleted.eq(false));
-
         return findAll(builder, pageable);
     }
 }
-

--- a/delivery/src/main/java/com/sparta/msa/delivery/presentation/controller/DeliveryManagerController.java
+++ b/delivery/src/main/java/com/sparta/msa/delivery/presentation/controller/DeliveryManagerController.java
@@ -71,19 +71,20 @@ public class DeliveryManagerController {
 
     // 배송 담당자 배정: MASTER만 가능
     @PutMapping("/assign")
-    public ResponseEntity<?> assignDeliveryManager(
+    public ResponseEntity<DeliveryManagerResponse> assignDeliveryManager(
             @RequestHeader("X-Username") String username,
             @RequestHeader("X-Role") String role
     ) {
         if (!isMaster(role)) {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
-        return ResponseEntity.ok("배송 담당자 배정 성공");
+        DeliveryManagerResponse response = deliveryManagerService.assignHubDeliveryManager();
+        return ResponseEntity.ok(response);
     }
 
     // 특정 허브의 업체 배송 담당자 배정: MASTER만 가능
     @PostMapping("/assign/company/{hubUUID}")
-    public ResponseEntity<?> assignCompanyDeliveryManager(
+    public ResponseEntity<DeliveryManagerResponse> assignCompanyDeliveryManager(
             @PathVariable UUID hubUUID,
             @RequestHeader("X-Username") String username,
             @RequestHeader("X-Role") String role
@@ -91,7 +92,7 @@ public class DeliveryManagerController {
         if (!isMaster(role)) {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
-        deliveryManagerService.assignCompanyDeliveryManager(hubUUID);
-        return ResponseEntity.ok("업체 배송 담당자 배정 성공");
+        DeliveryManagerResponse response = deliveryManagerService.assignCompanyDeliveryManager(hubUUID);
+        return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #74

## 📝 Description
기존에는 포괄적으로 배송 매니저 배정을 했는데 이번에는 허브 배송 담당자와 업체 배송 담당자를 구분했습니다. 또한 api 별로 권한에 맞게 작동하게끔 수정했습니다.

## 💬 To Reivewers

